### PR TITLE
Fixed memory leak and cleaned up addNode

### DIFF
--- a/lists.c
+++ b/lists.c
@@ -11,24 +11,20 @@ Node *head = NULL;
 // add a node to the list
 Node *addNode(int data)
 {
-    Node *new = NULL;
+    // allocate the new node
+    Node *new = malloc(sizeof(Node));
+    if (new == NULL)
+        return NULL;
+    
     // two cases:
 
     // if the list is empty.
     if (head == NULL)
     {
-        new = malloc(sizeof(Node));
-        if (new == NULL)
-            return NULL;
-        
         new->data = data;
         head = new;
         new->next = NULL;
     } else {
-        new = malloc(sizeof(Node));
-        if (new == NULL)
-            return NULL;
-        
         new->data = data;
         new->next = head;
         head = new;
@@ -52,10 +48,10 @@ int removeNode(int data)
                 head = current->next;
             } else {
                 prev->next = current->next;
-                free(current);
-                current = NULL;
             }
-
+            // deallocate the current node
+            free(current);
+            current = NULL;
             return 1;
         }
         prev = current;

--- a/lists.c
+++ b/lists.c
@@ -65,9 +65,10 @@ int removeNode(int data)
 Node *insertNode(int data, int position)
 {
     Node *current = head;
-    while (current != NULL && position != 0)
+    while (current->next != NULL && position != 0)
     {
         position--;
+        current = current->next;
     }
 
     if (position != 0)


### PR DESCRIPTION
There is a memory leak in removeNode, where the node is not deallocated if it is the first node in the list, and the addNode function only needs the call to malloc to occur in one place.

I saw the comment that noticed the mistake, I'm not the person that left it though.